### PR TITLE
Fix: adjusted recieve damage command and its test

### DIFF
--- a/spring-boot/src/main/java/org/springframework/ntfh/cardlogic/abilitycard/rogue/Trampa.java
+++ b/spring-boot/src/main/java/org/springframework/ntfh/cardlogic/abilitycard/rogue/Trampa.java
@@ -9,7 +9,7 @@ import org.springframework.ntfh.entity.player.Player;
 public class Trampa {
     public void execute(Player playerFrom, EnemyIngame targetedEnemy){
         targetedEnemy.getPlayedCardsOnMeInTurn().add(AbilityCardTypeEnum.TRAMPA);
-        new ReceiveDamageCommand(targetedEnemy.getCurrentEndurance(), targetedEnemy, playerFrom);
-        new DealDamageCommand(100, playerFrom, targetedEnemy).execute();
+        new ReceiveDamageCommand(targetedEnemy, playerFrom);
+        new DealDamageCommand(targetedEnemy.getCurrentEndurance(), playerFrom, targetedEnemy).execute();
     }
 }

--- a/spring-boot/src/main/java/org/springframework/ntfh/command/ReceiveDamageCommand.java
+++ b/spring-boot/src/main/java/org/springframework/ntfh/command/ReceiveDamageCommand.java
@@ -11,14 +11,13 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public class ReceiveDamageCommand implements Command {
 
-    private Integer damage;
-
     private EnemyIngame enemyFrom;
 
     private Player playerTo;
 
     @Override
     public void execute() {
+        Integer damage = enemyFrom.getCurrentEndurance();
         EnemyModifierType enemyModifier = enemyFrom.getEnemy().getEnemyModifierType();
         CharacterTypeEnum characterClass = playerTo.getCharacterTypeEnum();
         if (enemyFrom.getRestrained())

--- a/spring-boot/src/main/java/org/springframework/ntfh/entity/turn/concretestates/MarketState.java
+++ b/spring-boot/src/main/java/org/springframework/ntfh/entity/turn/concretestates/MarketState.java
@@ -48,7 +48,7 @@ public class MarketState implements TurnState {
         Player currentPlayer = game.getCurrentTurn().getPlayer();
         game.getEnemiesFighting().forEach(enemy -> {
             Integer damage = enemy.getCurrentEndurance();
-            new ReceiveDamageCommand(damage, enemy, currentPlayer).execute();
+            new ReceiveDamageCommand(enemy, currentPlayer).execute();
         });
 
         turnService.createNextTurn(game);

--- a/spring-boot/src/test/java/org/springframework/ntfh/commandtest/CommandIngameTest.java
+++ b/spring-boot/src/test/java/org/springframework/ntfh/commandtest/CommandIngameTest.java
@@ -434,14 +434,18 @@ public class CommandIngameTest {
 
         //recieve damage, not enough to wound
         
-        new ReceiveDamageCommand(2, enemyIngame, rogue).execute();
+        new ReceiveDamageCommand(enemyIngame, rogue).execute(); 
 
         assertThat(rogue.getDiscardPile().size()).isEqualTo(2);
         assertThat(rogue.getWounds()).isZero();
 
         //recieve damage beyond their current ability pile, ads wound
+        
+        EnemyIngame enemyIngame2 = enemyIngameService.createFromEnemy(enemyService.findEnemyById(15).get(), gameTester); //hard hitting enemy
 
-        new ReceiveDamageCommand(15, enemyIngame, rogue).execute();
+        new ReceiveDamageCommand(enemyIngame2, rogue).execute();
+        new ReceiveDamageCommand(enemyIngame2, rogue).execute();
+        new ReceiveDamageCommand(enemyIngame2, rogue).execute();
 
         assertThat(rogue.getAbilityPile().size()).isNotZero();
         assertThat(rogue.getDiscardPile().size()).isNotZero();
@@ -449,7 +453,7 @@ public class CommandIngameTest {
 
         //recieve damage and this damage kills
 
-        new ReceiveDamageCommand(13, enemyIngame, rogue).execute();
+        new ReceiveDamageCommand(enemyIngame, rogue).execute();
 
         assertThat(rogue.getWounds()).isEqualTo(2);
         assertThat(rogue.isDead()).isTrue();


### PR DESCRIPTION
It no longer needs to recieve the damage as an input, it is now calculated automatically inside the controller, as the damage is ALWAYS the current endurance of the enemy with the modifications set in the recieve damage command